### PR TITLE
recorder set as in CH-VACD, issue#21

### DIFF
--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -28,7 +28,8 @@ It documents the relevant allergies or intolerances (conditions) for a patient, 
 * patient only Reference(CHCorePatient)
 * onsetDateTime only dateTime
 * onsetDateTime MS
-* recorder only Reference(CHCorePractitionerRole or CHCorePatient)
+* recorder only Reference(CHCorePractitioner or CHCorePractitionerRole or CHCorePatient or RelatedPerson)
+* asserter only Reference(CHCorePractitioner or CHCorePractitionerRole or CHCorePatient or RelatedPerson)
 * reaction MS
 * reaction.extension contains $ext-allergyintolerance-certainty named certainty 0..1
 * reaction.extension[certainty] ^short = "certainty: Statement about the degree of clinical certainty that the specific substance was the cause of the manifestation in this reaction event."
@@ -202,3 +203,5 @@ It documents the relevant allergies or intolerances (conditions) for a patient, 
 * code from CHAllergyIntoleranceValueSet (preferred)
 * bodySite 0..* MS
 * subject only Reference(CHCorePatient)
+* recorder only Reference(CHCorePractitioner or CHCorePractitionerRole or CHCorePatient or RelatedPerson)
+* asserter only Reference(CHCorePractitioner or CHCorePractitionerRole or CHCorePatient or RelatedPerson)

--- a/input/fsh/profiles.fsh
+++ b/input/fsh/profiles.fsh
@@ -28,6 +28,7 @@ It documents the relevant allergies or intolerances (conditions) for a patient, 
 * patient only Reference(CHCorePatient)
 * onsetDateTime only dateTime
 * onsetDateTime MS
+* recorder only Reference(CHCorePractitionerRole or CHCorePatient)
 * reaction MS
 * reaction.extension contains $ext-allergyintolerance-certainty named certainty 0..1
 * reaction.extension[certainty] ^short = "certainty: Statement about the degree of clinical certainty that the specific substance was the cause of the manifestation in this reaction event."


### PR DESCRIPTION
Hallo @ralych , ich habe nun gemäss issue#21 wie in VACD 
* recorder only Reference(CHCorePractitionerRole or CHCorePatient)
in fsh gesetzt. Was ist der Grund, dass ggü. dem Base Profile Practitioner und Related Person weggelassen worden sind?
LG Walter